### PR TITLE
Test on rust 1.79.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,7 @@ jobs:
           - ubuntu-24.04
           - macos-14
         rust:
+          - 1.77.2
           - 1.81.0
         mode:
          - debug

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
           - ubuntu-24.04
           - macos-14
         rust:
-          - 1.77.2
+          - 1.79.0
           - 1.81.0
         mode:
          - debug

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="src/ims/arrcomp_anim.svg" width="600">
 
-List comprehension-style syntax for creating Rust array using declarative macros.
+List comprehension-style syntax for creating Rust arrays using declarative macros.
 
 In contrast to most Rust packages of this sort, arrcomp exclusively creates fixed size
 arrays without an intermediate heap allocation. This is more performant than standard

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc(html_logo_url = "https://github.com/janbridley/arrcomp/blob/main/src/ims/arrcomp.svg")]
 
 /*!
-List comprehension-style syntax for creating Rust array using declarative macros.
+List comprehension-style syntax for creating Rust arrays using declarative macros.
 
 In contrast to most Rust packages of this sort, arrcomp exclusively creates fixed size
 arrays without an intermediate heap allocation. This is more performant than standard


### PR DESCRIPTION
`Cargo.lock` v4 files are not supported for rs 1.77.2, and pre-commit autoupdates the file to v4. The previous 1.77.2 tests have been moved to 1.79.0 to avoid this issue.